### PR TITLE
Correct maxerrors conditional by reversing the comparison operator

### DIFF
--- a/moira/moira.py
+++ b/moira/moira.py
@@ -674,7 +674,7 @@ def check_arguments(args):
             if not args.nowarnings:
                 print '- The uncert parameter must be between 0 (not included) and 1.'
             ok = False
-        if args.maxerrors >= 0:
+        if args.maxerrors <= 0:
             if not args.nowarnings:
                 print '- The maxerrors parameter must be greater than 0.'
             ok = False


### PR DESCRIPTION
Small change to get the maxerrors option to recognize any value > 0.
